### PR TITLE
Publication improvements

### DIFF
--- a/rethink-client.js
+++ b/rethink-client.js
@@ -115,8 +115,8 @@ Rethink.Table.prototype._registerStore = function () {
         if (! doc)
           throw new Error("Expected to find a document to change");
         self._localOnly = true;
-        self._localOnly = false;
         self.get(id).update(msg.fields).run();
+        self._localOnly = false;
       } else {
         throw new Error("I don't know how to deal with this message");
       }

--- a/rethink-client.js
+++ b/rethink-client.js
@@ -142,7 +142,7 @@ Rethink.Table.prototype._registerStore = function () {
 };
 
 Rethink.Table.prototype._makeNewID = function () {
-  var src = name ? DDP.randomStream('/collection/' + this.name) : Random;
+  var src = this.name ? DDP.randomStream('/collection/' + this.name) : Random;
   return src.id();
 };
 

--- a/rethink-client.js
+++ b/rethink-client.js
@@ -64,7 +64,8 @@ Rethink.Table.prototype._registerStore = function () {
 
   var ok = self._connection.registerStore(self.name, {
     beginUpdate: function (batchSize, reset) {
-      console.log('begin update'); return;
+      //console.log('begin update'); return;
+      return;
       if (batchSize > 1 || reset)
         self._pauseObservers();
       if (reset) {
@@ -122,7 +123,7 @@ Rethink.Table.prototype._registerStore = function () {
       }
     },
     endUpdate: function () {
-      console.log('endupdate')
+      //console.log('endupdate')
       return;
       self._resumeObservers();
     },

--- a/rethink.js
+++ b/rethink.js
@@ -64,7 +64,7 @@ Rethink.Table = function (name, options) {
 // publishing arrays of cursors
 Rethink.Table.prototype._getCollectionName = function () {
   return this.name;
-};;
+};
 
 attachCursorMethod('_getCollectionName', function () {
   return function () {
@@ -255,8 +255,10 @@ var observe = function (callbacks) {
       // Because they give you an initial value, there's
       // no need to get it and return it on .added
       var initializing = true;
-      // Send the initial value here
-      cbs.added(initialResult);
+      if (initialResult) {
+        // Send the initial value here
+        cbs.added(initialResult);
+      }
       // Unblock
       initValuesFuture.return();
       // Start the change-feed
@@ -288,7 +290,7 @@ var observe = function (callbacks) {
       }
     };
   } catch (e) {
-    cbs.error(e);
+    initValuesFuture.isResolved() ? cbs.error(e) : initValuesFuture.throw(e);
   }
 };
 
@@ -332,7 +334,7 @@ Rethink.Table._publishCursor = function (cursor, sub, tableName) {
 
   // register stop callback (expects lambda w/ no args).
   sub.onStop(function () {
-    observeHandle.stop();
+    observeHandle && observeHandle.stop();
   });
 };
 

--- a/rethink.js
+++ b/rethink.js
@@ -252,11 +252,8 @@ var observe = function (callbacks) {
       // Handle single point queries here.
       var initializing = true;
       if (initialResult) {
-        // Send the initial value here
-        Meteor.defer(function () {
-          // This is to make sure it's Fiber-wrapped
-          cbs.added(initialResult);  
-        });
+        // Send the initial value here, Fiber-wrapped
+        Meteor.bindEnvironment(cbs.added.bind(cbs, initialResult))();
       }
       // Unblock
       initValuesFuture.return();

--- a/rethink.js
+++ b/rethink.js
@@ -59,6 +59,19 @@ Rethink.Table = function (name, options) {
   self._connection.methods(methods);
 };
 
+
+// These injected methods _getCollectionName are to allow
+// publishing arrays of cursors
+Rethink.Table.prototype._getCollectionName = function () {
+  return this.name;
+};;
+
+attachCursorMethod('_getCollectionName', function () {
+  return function () {
+    return this._table.name;
+  };
+});
+
 Rethink.Table._checkName = function (name) {
   var tables = r.tableList().run(connection);
   if (tables.indexOf(name) === -1)

--- a/rethink.js
+++ b/rethink.js
@@ -59,19 +59,6 @@ Rethink.Table = function (name, options) {
   self._connection.methods(methods);
 };
 
-
-// These injected methods _getCollectionName are to allow
-// publishing arrays of cursors
-Rethink.Table.prototype._getCollectionName = function () {
-  return this.name;
-};
-
-attachCursorMethod('_getCollectionName', function () {
-  return function () {
-    return this._table.name;
-  };
-});
-
 Rethink.Table._checkName = function (name) {
   var tables = r.tableList().run(connection);
   if (tables.indexOf(name) === -1)
@@ -150,6 +137,18 @@ attachCursorMethod('fetch', function () {
   return function () {
     var self = this;
     return wait(self.run().toArray());
+  };
+});
+
+// These injected methods _getCollectionName are to allow
+// publishing arrays of cursors
+Rethink.Table.prototype._getCollectionName = function () {
+  return this.name;
+};
+
+attachCursorMethod('_getCollectionName', function () {
+  return function () {
+    return this._table.name;
   };
 });
 

--- a/rethink.js
+++ b/rethink.js
@@ -257,7 +257,10 @@ var observe = function (callbacks) {
       var initializing = true;
       if (initialResult) {
         // Send the initial value here
-        cbs.added(initialResult);
+        Meteor.defer(function () {
+          // This is to make sure it's Fiber-wrapped
+          cbs.added(initialResult);  
+        });
       }
       // Unblock
       initValuesFuture.return();

--- a/rethink.js
+++ b/rethink.js
@@ -223,13 +223,11 @@ var observe = function (callbacks) {
   var streamCursor;
   var initValuesFuture = new Future();
   
-  // Get initial results first
-  // XXX Need to handle queries that literally don't return cursors
-  // but rather return single documents
   try {
+    // Get initial results first
     var initialResult = self.run();
     // Check if it's iterable, if not, it means it's a single document
-    // returned by a query like .min() or .max()
+    // returned by a query like .min(), .max(), or .get()
     if (_.isFunction(initialResult.each)) {
       initialResult.each(Meteor.bindEnvironment(function (err, doc) {
         if (!err) {
@@ -246,14 +244,12 @@ var observe = function (callbacks) {
           initValuesFuture.return();
         }
         // After all initial values have been gotten, then we can create
-        // our awesome change feeds! Yea!
+        // our awesome change-feeds! Yea!
         streamCursor = self.changes().run();
         streamCursor.each(Meteor.bindEnvironment(changeFeedHandler.bind(cbs)));
       }));
     } else {
       // Handle single point queries here.
-      // Because they give you an initial value, there's
-      // no need to get it and return it on .added
       var initializing = true;
       if (initialResult) {
         // Send the initial value here


### PR DESCRIPTION
WIP.

Can publish more stuff such as:

``` js
.min()
.max()
.filter()
// Apparently you have to do orderBy first before you filter, otherwise it doesn't work (https://github.com/rethinkdb/rethinkdb/issues/4266)
.orderBy().filter().limit()
.get()
.pluck() // you need to at least have 'id' in there or you're screwed
// This doesn't work unfortunately (https://github.com/rethinkdb/rethinkdb/issues/4267)
// .get().pluck()
.map()
```

I've also tried a mixture of the above with success. I'll document more.

You can also do things like:

``` js
Meteor.publish('allCities', function () {
  return Cities;
});

Meteor.publish('allCitiesAndStates', function () {
  return [Cities, States];
});

Meteor.publish('citiesAndStatesMoreIntelligently', function () {
  return [
    Cities.orderBy({ index: 'id' }).limit(10), 
    States.filter({ region: 'northWest' })
  ];
});
```

Untested queries:

``` js
.union()
.between()
```

Essentially I was just going through [this list](http://rethinkdb.com/docs/changefeeds/javascript/) and testing them out.

I haven't wrote tests yet.

FYIs:
Each session creates a change-feed. Don't know if it makes sense to share change-feeds per session maybe or does this go against mergebox implementations?

Also, is there any way on the server to make a `Rethink.Table` act like a `r.table`? If it wasn't for that `.filter({})` prefix, most of this wouldn't work.

Client-side hasn't changed though.

I tried to implement Michel's (neumino) new stuff but broke the current browserified build implementation because he made tons of changes.
