### PR TITLE
Fix for breaking change in rethinkdb@2.2.0, must specify incudeInitial

### DIFF
--- a/rethink.js
+++ b/rethink.js
@@ -183,7 +183,7 @@ var observe = function (callbacks) {
   var initValuesFuture = new Future;
   var initializing = false;
 
-  var stream = self.union().changes({ includeStates: true }).run();
+  var stream = self.union().changes({ includeStates: true, includeInitial: true }).run();
   stream.each(Meteor.bindEnvironment(function (err, notif) {
     if (err) {
       if (initValuesFuture.isResolved())


### PR DESCRIPTION
Fix for breaking change in rethinkdb@2.2.0, must specify incudeInitial: true to encounter initializing notif.state.

See rethinkdb 2.2.0 API-Breaking changes section here: https://github.com/rethinkdb/rethinkdb/releases/tag/v2.2.0

Omitting includeInitial caused all queries to fail. Evidenced in demo project issue here: https://github.com/Slava/meteor-rethinkdb-demo/issues/1
