### PR TITLE
fix typo in client error creation

### DIFF
--- a/rethink-client-utils.js
+++ b/rethink-client-utils.js
@@ -16,7 +16,7 @@ PkMap.prototype.forEach = function (cb) {
     }
 };
 
-mkErr = function (ErrClass, repsponse) {
+mkErr = function (ErrClass, response) {
   return new ErrClass(mkAtom(response), response.b);
 }
 
@@ -97,4 +97,3 @@ function convertPseudotype (obj) {
       return obj;
   }
 }
-


### PR DESCRIPTION
There are other issues with errors, but this one was easy to spot, so here it is.
